### PR TITLE
[Build] Pin `openassetio-traitgen` to `v1.0.0a7`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Traitgen
-        run: python -m pip install openassetio-traitgen==1.0.0a6
+        run: python -m pip install openassetio-traitgen==1.0.0a7
 
       - name: Get OpenAssetIO
         uses: actions/download-artifact@v3
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Traitgen
-        run: python -m pip install openassetio-traitgen==1.0.0a6
+        run: python -m pip install openassetio-traitgen==1.0.0a7
 
       - name: Configure CMake build
         run: >

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Improvements
+
+- Pinned `openassetio-traitgen` to `v1.0.0a7` to ensure backwards
+  compatibility with `openassetio` `v1.0.0a14`.
+  [#60](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/issues/60)
+
 v1.0.0-alpha.7
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [build-system]
 requires = [
     "setuptools>=65.5.0",
-    "openassetio-traitgen>=1.0.0a6"
+    "openassetio-traitgen==1.0.0a7"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This ensures backwards compatability whilst commercially available hosts are still using `a14`.

Closes #60